### PR TITLE
Enable mixed content in web view for lollipop

### DIFF
--- a/Android-SDK-Source/mobileconnect/AndroidManifest.xml
+++ b/Android-SDK-Source/mobileconnect/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="8"
-        android:targetSdkVersion="8" />
+        android:targetSdkVersion="21" />
 
     <uses-permission android:name="android.permission.INTERNET"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/Android-SDK-Source/mobileconnect/src/com/gsma/android/mobileconnect/authorization/Authorization.java
+++ b/Android-SDK-Source/mobileconnect/src/com/gsma/android/mobileconnect/authorization/Authorization.java
@@ -1,5 +1,6 @@
 package com.gsma.android.mobileconnect.authorization;
 
+import android.os.Build;
 import java.util.HashMap;
 
 import android.annotation.SuppressLint;
@@ -140,7 +141,7 @@ public class Authorization {
 			final String _clientId=clientId;
 			final String _clientSecret=clientSecret;
 			final String _scopes=scopes;
-			
+
 			final WebView view = new WebView(activity);
 
 			LayoutParams fillParent=new LayoutParams(LayoutParams.FILL_PARENT,LayoutParams.FILL_PARENT);
@@ -246,6 +247,13 @@ public class Authorization {
 			settings.setDatabaseEnabled(true);
 			String databasePath = activity.getApplicationContext().getDir("database", Context.MODE_PRIVATE).getPath(); 
 		    settings.setDatabasePath(databasePath);
+
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+				// If the app targets LOLLIPOP or above the default web view behavior is
+				// to completely deny mixed content. As mobile connect requires the use of
+				// http during header enrichment we need a more relaxed security setting.
+				settings.setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
+			}
 
 			/*
 			 * load the specified URI along with the authorization header


### PR DESCRIPTION
Web views launched by apps targeting lollipop or above
defaults to denying all mixed content requests. This is
a problem for mobile connect identity providers who rely
on mixed content to perform header enrichment.

This patch relaxes the security settings for web views
when running on lollipop or above.

Ref http://developer.android.com/reference/android/webkit/WebSettings.html#setMixedContentMode%28int%29
